### PR TITLE
fix: wrong Flowtypes name

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Flood/FlowTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Flood/FlowTypes.ts
@@ -190,13 +190,13 @@ export interface AbstractEnum {
 
 // CanonicalRendersForm types
 export type CanonicalRendersForm =
-  | InstrinsicRenders
+  | IntrinsicRenders
   | NominalRenders
   | StructuralRenders
   | DefaultRenders;
 
-export interface InstrinsicRenders {
-  kind: 'InstrinsicRenders';
+export interface IntrinsicRenders {
+  kind: 'IntrinsicRenders';
   name: string;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix typo in FlowTypes by renaming InstrinsicRenders to IntrinsicRenders in both the type union and interface definition.